### PR TITLE
Updating constraints in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
         "typo3-ter/hh-slider": "self.version"
     },
     "require": {
-        "typo3/cms-core": "^9.5.0 || ^10.4.99",
-        "typo3/cms-fluid": "^9.5.0 || ^10.4.99",
-        "typo3/cms-frontend": "^9.5.0 || ^10.4.99",
-        "typo3/cms-fluid-styled-content": "^9.5.0 || ^10.4.99"
+        "typo3/cms-core": "^9.5.0 || ^10.2",
+        "typo3/cms-fluid": "^9.5.0 || ^10.2",
+        "typo3/cms-frontend": "^9.5.0 || ^10.2",
+        "typo3/cms-fluid-styled-content": "^9.5.0 || ^10.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fixing composer requirements for typo3 10 LTS
Installation should now also be possible with stable version of typo3 10 via composer.