### PR TITLE
[BUGFIX] Replace condition for ext:hh_video_extender

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -65,14 +65,5 @@ tt_content.hhslider_hh_slider {
                 preload = 1
             }
         }
-
-        hh_video_extender {
-            isLoaded = 0
-        }
     }
 }
-
-### Check if EXT:hh_video_extender isLoaded
-[{$plugin.tx_hhvideoextender.isLoaded} == 1]
-    tt_content.hhslider_hh_slider.settings.hh_video_extender.isLoaded = 1
-[global]

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -31,4 +31,11 @@ call_user_func(function() {
 
     // Register the class to be available in 'eval' of TCA
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals']['HauerHeinrich\\HhSlider\\Evaluation\\JsonEvaluation'] = '';
+
+    // Check if ext:hh_video_extender is loaded
+    if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('hh_video_extender')) {
+        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
+            'tt_content.hhslider_hh_slider.settings.hh_video_extender.isLoaded = 1'
+        );
+    }
 });


### PR DESCRIPTION
This fixes an TypoScript error thrown if extension hh_video_extender is not installed (**TYPO3 v10.4.9**).

```
TYPO3.CMS.Frontend.Configuration.TypoScript.ConditionMatching.ConditionMatcher": 
Expression could not be parsed. - {"expression":"{$plugin.tx_hhvideoextender.isLoaded} == 1"}
```

I've also evaluated other options (e.g. adding a custom condition) but this solution seems to be more lightweight to me.